### PR TITLE
chore: add .nvmrc (lts/carbon)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/carbon


### PR DESCRIPTION
Dodaje `.nvmrc` z `lts/carbon`.

dopasowane do engines '8.x' (Node 8).

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.